### PR TITLE
fix: use wild card certificate

### DIFF
--- a/contrib/frontend.yaml
+++ b/contrib/frontend.yaml
@@ -30,14 +30,3 @@ spec:
   tls:
   - hosts:
     - status.FIXME
-    secretName: status-ingress-cert
----
-# OPTIONAL: rip this/secretName part above out or update it if you aren't using kube-cert-manager.
-apiVersion: stable.k8s.psg.io/v1
-kind: Certificate
-metadata:
-  name: status-ingress
-spec:
-  domain: status.FIXME
-  provider: route53
-  secretName: status-ingress-cert


### PR DESCRIPTION
The reason for this pull request is the update of the cert-manager object
I'm not sure that I did everything right here.
I've tried to follow next doc: http://docs.cert-manager.io/en/latest/tutorials/acme/dns-validation.html

```
apiVersion: certmanager.k8s.io/v1alpha1
kind: Certificate
metadata:
  name: example-com
  namespace: default
spec:
  secretName: example-com-tls
  issuerRef:
    name: letsencrypt-staging
  commonName: '*.example.com'
  dnsNames:
  - example.com
  - foo.com
  acme:
    config:
    - dns01:
        provider: prod-dns
      domains:
      - '*.example.com'
      - example.com
    - dns01:
        provider: cf-dns
      domains:
      - foo.com
```