### PR TITLE
fix: prepare manifests for one level wildcard

### DIFF
--- a/contrib/frontend.yaml
+++ b/contrib/frontend.yaml
@@ -20,7 +20,7 @@ metadata:
   name: e2etests
 spec:
   rules:
-  - host: status.FIXME
+  - host: kube-e2etests.FIXME
     http:
       paths:
       - path: /
@@ -29,4 +29,4 @@ spec:
           servicePort: http
   tls:
   - hosts:
-    - status.FIXME
+    - kube-e2etests.FIXME


### PR DESCRIPTION
this is required in order to migrate from one DNS to more simple (first level wildcard certificate)