### PR TITLE
feat: Add custom template labels for deployments

### DIFF
--- a/kubee2etests/deployment.py
+++ b/kubee2etests/deployment.py
@@ -17,12 +17,14 @@ class Deployment(ApiMixin):
     def __init__(self, name, namespace, replicas=e2e_globals.TEST_REPLICAS,
                  cfgmap_name=e2e_globals.TEST_INDEX_NAME,
                  labels=e2e_globals.TEST_LABELS,
+                 template_labels=e2e_globals.TEST_TEMPLATE_LABELS,
                  vol_claim=None):
         super().__init__(namespace=namespace)
         self.name = name
         self.replicas = replicas
         self.cfgmap_name = cfgmap_name
         self.labels = labels
+        self.template_labels = template_labels
         self.vol_claim_name = vol_claim
         # Api used for deployment methods. Core api used for any pod methods
         self.extensions_api = client.ExtensionsV1beta1Api()
@@ -32,7 +34,7 @@ class Deployment(ApiMixin):
 
     @property
     def label_selector(self):
-        return ",".join(["%s=%s" % (key, value) for key, value in self.labels.items()])
+        return ",".join(["%s=%s" % (key, value) for key, value in self.template_labels.items()])
 
     @property
     def k8s_object(self):
@@ -50,7 +52,7 @@ class Deployment(ApiMixin):
                 ),
                 template=client.V1PodTemplateSpec(
                     metadata=client.V1ObjectMeta(
-                        labels=self.labels),
+                        labels=self.template_labels),
                     spec=client.V1PodSpec(
                         affinity=client.V1Affinity(
                             pod_anti_affinity=client.V1PodAntiAffinity(

--- a/kubee2etests/helpers_and_globals.py
+++ b/kubee2etests/helpers_and_globals.py
@@ -59,8 +59,11 @@ TEST_VOLUME_CLAIM_NAME = 'test-claim'
 
 TEST_REPLICAS = 3
 CUSTOM_LABELS = ast.literal_eval(os.environ.get("CUSTOM_TEST_DEPLOYMENT_LABELS", '{}'))
+CUSTOM_TEMPLATE_LABELS = ast.literal_eval(os.environ.get("CUSTOM_TEST_DEPLOYMENT_TEMPLATE_LABELS", '{}'))
 TEST_LABELS = {'app': 'hellominikube'}
 TEST_LABELS.update(CUSTOM_LABELS)
+TEST_TEMPLATE_LABELS = {'app': 'hellominikube'}
+TEST_TEMPLATE_LABELS.update(CUSTOM_TEMPLATE_LABELS)
 TEST_CONTAINER_PORT = 80
 
 # time to wait for events before timing out, used in wait_on_event

--- a/kubee2etests/runners/deployment_runners.py
+++ b/kubee2etests/runners/deployment_runners.py
@@ -8,6 +8,7 @@ class DeploymentRunner(RunnerBase):
                  replicas=e2e_globals.TEST_REPLICAS, cfgmap_name=e2e_globals.TEST_INDEX_NAME,
                  cfgmap_index=e2e_globals.TEST_DEPLOYMENT_INDEX,
                  labels=e2e_globals.TEST_LABELS,
+                 template_labels=e2e_globals.TEST_TEMPLATE_LABELS,
                  volume_claim=None,
                  claim_storage=None,
                  **kwargs):
@@ -18,7 +19,8 @@ class DeploymentRunner(RunnerBase):
                                                 namespace,
                                                 replicas,
                                                 cfgmap_name,
-                                                labels)
+                                                labels,
+                                                template_labels)
         self.cfgmap = ConfigMap(name=cfgmap_name,
                                 index=cfgmap_index,
                                 namespace=namespace)

--- a/kubee2etests/runners/runnerbase.py
+++ b/kubee2etests/runners/runnerbase.py
@@ -34,10 +34,12 @@ class RunnerBaseWithDeployment(RunnerBase):
                  deployment,
                  replicas=e2e_globals.TEST_REPLICAS,
                  labels=e2e_globals.TEST_LABELS,
+                 template_labels=e2e_globals.TEST_TEMPLATE_LABELS,
                  cfgmap=e2e_globals.TEST_INDEX_NAME, **kwargs):
         super().__init__(namespace)
         self.labels = labels
-        self.deployment = Deployment(deployment, namespace, replicas, cfgmap, labels)
+        self.template_labels = template_labels
+        self.deployment = Deployment(deployment, namespace, replicas, cfgmap, labels, template_labels)
         self.cfgmap = ConfigMap(name=cfgmap,
                                 index=TEST_DEPLOYMENT_INDEX,
                                 namespace=self.namespace)

--- a/kubee2etests/service.py
+++ b/kubee2etests/service.py
@@ -29,7 +29,7 @@ class Service(ApiMixin):
                                 spec=client.V1ServiceSpec(ports=[
                                     client.V1ServicePort(port=10, target_port=e2e_globals.TEST_CONTAINER_PORT),
                                 ],
-                                    selector=e2e_globals.TEST_LABELS)
+                                    selector=e2e_globals.TEST_TEMPLATE_LABELS)
                                 )
 
     def _read_from_k8s(self, should_exist=True):


### PR DESCRIPTION
Add ability to create custom labels and custom template labels for deployments separately. 
Part of backlog[#939](https://gitlab.tech.lastmile.com/osp-cfc-platform/backlog/issues/939)